### PR TITLE
Sdist fix

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include *.md LICENSE* NOTICE*
+recursive-include src *.pyx 

--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,10 @@ if USE_CYTHON:
 
 setup(
   name='spavro',
-  version='1.1.2+patch1',
+  version='1.1.2+patch2',
   packages=['spavro'],
   package_dir={'': 'src'},
   # scripts=["./scripts/avro"],
-  include_package_data=True,
   # Project uses simplejson, so ensure that it gets installed or upgraded
   # on the target machine
   install_requires=install_requires,

--- a/setup.py
+++ b/setup.py
@@ -25,12 +25,11 @@ if USE_CYTHON:
 
 setup(
   name='spavro',
-  version='1.1.2',
+  version='1.1.2+patch1',
   packages=['spavro'],
   package_dir={'': 'src'},
   # scripts=["./scripts/avro"],
   include_package_data=True,
-  package_data={'spavro': ['LICENSE.txt', 'NOTICE.txt']},
   # Project uses simplejson, so ensure that it gets installed or upgraded
   # on the target machine
   install_requires=install_requires,


### PR DESCRIPTION
Fix install from sdist when Cython is installed

Installing from the PyPI sdist failed when one has Cython installed.
This is because the sdist did not include the pyx file in the
source distribution. The setup.py tested that Cython was installed,
and when it was, it tried to compile from the pyx source, even though
it was not included in the sdist.

Fix inclusion of the pyx file, CHANGELOG.md, LICENSE.txt, NOTICE.txt
in the source distribution.