### PR TITLE
Seek the write buffer to zero after flushing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
 matrix:
   include:
+    - python: 3.3
+      dist: trusty
+      sudo: true
     - python: 3.7
       dist: xenial
       sudo: true

--- a/src/spavro/datafile.py
+++ b/src/spavro/datafile.py
@@ -208,7 +208,8 @@ class DataFileWriter(object):
             self.writer.write(self.sync_marker)
 
             # reset buffer
-            self.buffer_writer.truncate(0) 
+            self.buffer_writer.truncate(0)
+            self.buffer_writer.seek(0)
             self.block_count = 0
 
     def append(self, datum):


### PR DESCRIPTION
While `.truncate(0)` is called on the buffer object
after writing, this won't reset the current position
to zero. Subsequent writes will therefore just keep
extending the buffer and writing more and more data.
The fix is pretty simple -- `.seek(0)` after truncating.

It looks like this will come up any time an avro file
grows past 64,000 bytes (i.e., SYNC_INTERVAL bytes).